### PR TITLE
OCPBUGS-44103: handle DeserializedImageIndex manifests

### DIFF
--- a/pkg/cli/image/mirror/mirror.go
+++ b/pkg/cli/image/mirror/mirror.go
@@ -611,6 +611,9 @@ func (o *MirrorImageOptions) plan() (*plan, error) {
 									case *schema2.DeserializedManifest:
 									case *schema1.SignedManifest:
 									case *ocischema.DeserializedManifest:
+									case *ocischema.DeserializedImageIndex:
+										// we do not need to upload layers in an image index
+										return
 									case *manifestlist.DeserializedManifestList:
 										// we do not need to upload layers in a manifestlist
 										return


### PR DESCRIPTION
This fixes the following error:
```
  stats: shared=0 unique=0 size=0Berror: the manifest type *ocischema.DeserializedImageIndex is not supported
error: an error occurred during planning
```
by parsing the DeserializedImageIndex as we do with DeserializedManifestList.