### PR TITLE
Skip message when mirroring to disk using oc-mirror

### DIFF
--- a/pkg/cli/admin/catalog/mirror.go
+++ b/pkg/cli/admin/catalog/mirror.go
@@ -718,7 +718,10 @@ func WriteManifests(out io.Writer, source, dest imagesource.TypedImageReference,
 
 	fmt.Fprintf(out, "wrote mirroring manifests to %s\n", dir)
 
-	if dest.Type == imagesource.DestinationFile {
+	// Don't print 'oc adm catalog mirror' message when using oc-mirror
+	cmdPath := strings.Split(os.Args[0], "/")
+	cmd := cmdPath[len(cmdPath)-1]
+	if dest.Type == imagesource.DestinationFile && !strings.Contains(cmd, "mirror") {
 		localIndexLocation, err := mount(source, dest, 0)
 		if err != nil {
 			return err


### PR DESCRIPTION
When mirroring files to disk using `oc-mirror` v1, either standalone or as an `oc` plugin, a ~helpful~ message was printed suggesting to use the `oc adm catalog mirror` command for continuation.

Below is the example message output when using `oc-mirror` with a destination containing the `file://` prefix:

```
To upload local images to a registry, run:

	oc adm catalog mirror file://path/to/index:v4.17 REGISTRY/REPOSITORY
```

The `oc-mirror` command links to the same code within `oc`. There are two problems that arise due to how these two tools differ:

1. It confuses users into thinking that 2 different tools are necessary to mirror an index for offline use.

2. The source filename is also incorrect, as it prints the file name as `<source/index-image:tag>` instead of `<filename>.tar`.

This change simply skips the message printout if the calling command name is either `<command>-mirror` or `<command> mirror` (where `<command>` is either `oc` or `kubectl`) to catch standalone and plugin use cases.

Absolute (or relative) path names such as `/path/to/<command>-mirror` are also handled.